### PR TITLE
Fixes #4 - Add .mtk1

### DIFF
--- a/theme-pitchblack.css
+++ b/theme-pitchblack.css
@@ -963,3 +963,7 @@ img[src$="/img/matrix.svg"] {
     background: var(--color-body);
     background-color: var(--color-body)
 }
+
+.mtk1 {
+    color: #6D7178!important
+}

--- a/theme-pitchblack.less
+++ b/theme-pitchblack.less
@@ -873,3 +873,7 @@ img[src$="/img/matrix.svg"] {
     background: var(--color-body);
     background-color: var(--color-body);
 }
+
+.mtk1 {
+    color: #6D7178!important;
+}


### PR DESCRIPTION
Default color is `#000`. This hard overrides it to a font color more visible in dark and light background.