### PR TITLE
Fixed missing toolbar colors for Gitea 1.20+

### DIFF
--- a/theme-pitchblack.css
+++ b/theme-pitchblack.css
@@ -198,6 +198,8 @@
   --color-placeholder-text: #6a737d;
   --color-editor-line-highlight: var(--color-primary-light-5);
   --color-project-board-bg: var(--color-secondary-light-2);
+  --color-nav-bg: var(--color-body);
+  --color-nav-hover-bg: var(--color-hover);
 }
 
 ::-webkit-calendar-picker-indicator {

--- a/theme-pitchblack.less
+++ b/theme-pitchblack.less
@@ -108,6 +108,8 @@
   --color-placeholder-text: #6a737d;
   --color-editor-line-highlight: var(--color-primary-light-5);
   --color-project-board-bg: var(--color-secondary-light-2);
+  --color-nav-bg: var(--color-body);
+  --color-nav-hover-bg: var(--color-hover);
 }
 
 ::-webkit-calendar-picker-indicator {


### PR DESCRIPTION
Small patch to fix theme on Gitea 1.20+
(see [issue #9](https://github.com/iamdoubz/Gitea-Pitch-Black/issues/9))